### PR TITLE
Adds `build-essential` debian package

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER jitpack <jitpack@jitpack.io>
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \ 
-	apt-get install -y --no-install-recommends file git curl wget zip unzip xz-utils nano less && \
+	apt-get install -y --no-install-recommends file git curl wget zip unzip xz-utils nano less build-essential && \
 	apt-get install -y libncurses5:i386 libc6:i386 libstdc++6:i386 lib32gcc1 lib32z1 zlib1g:i386 && \
 	apt-get install -y --no-install-recommends openjdk-8-jdk openjfx && \
 	apt-get clean && \


### PR DESCRIPTION
I have a use case where I'm building a rust library for use by android. Rust needs a c compiler on the path and without it I can't use jitpack, which I really want to because it seems like exactly what I need.

If this not something you want to support, that's all good. Just thought it might be an easy change.